### PR TITLE
Allow configuration of `php` binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ phpenmod: Ini file not found. Trying to create new...
 phpenmod: Done.
 ```
 
+#### Use with a different PHP version
+```
+[ru@ru-manjaro php.d]$ export PHP_BIN=php81
+[ru@ru-manjaro php.d]$ phpenmod readline mbstring
+```
+
 #### Listing scan directory
 ```
 ls /etc/php/php.d/

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ make -j4 && sudo make install
 ```
 
 ### Extension installation
+```
 cd ~/src/php-src/ext/readline
 phpize && ./configure && make -j4 && sudo make install
 cd ~/src/php-src/ext/mbstring
 phpize && ./configure && make -j4 && sudo make install
+```
 
 ### phpenmod installation
 ```

--- a/phpenmod
+++ b/phpenmod
@@ -288,7 +288,7 @@ while read -r line; do
 done <<< $PARAMS
 
 # check if Scan this dir for additional .ini files is not empty
-[[ SCAN != "(none)" ]] && echo -e "please build with ./configure --with-config-file-scan-dir=PATH\n" && exit 1
+[[ $SCAN == "(none)" ]] && echo -e "please build with ./configure --with-config-file-scan-dir=PATH\n" && exit 1
 
 # integer return value variable
 declare -i RETVAL=0

--- a/phpenmod
+++ b/phpenmod
@@ -262,9 +262,11 @@ dismod() {
 ################################################################################
 SCRIPT_NAME=${0##*/}
 
+PHP_BIN=${PHP_BIN:-php}
+
 # check if php is installed
 # redirect stderr to stdout
-OUT=`exec which php 2>&1`
+OUT=`exec which $PHP_BIN 2>&1`
 if [[ -z "$OUT" ]]; then
   log "$OUT"
   log "PHP is not installed" RED
@@ -272,7 +274,7 @@ if [[ -z "$OUT" ]]; then
 fi
 
 # read PHP parameters
-PARAMS=`php -i | grep --color \
+PARAMS=`$PHP_BIN -i | grep --color \
        -e "^extension_dir =>" \
        -e "^Scan this dir for additional .ini files =>" \
        `


### PR DESCRIPTION
Add a variable to set the name of the php binary.
This feature allows a user to choose the different available versions.